### PR TITLE
allow files to be excluded from the cache refresh

### DIFF
--- a/core/components/statcache/elements/plugins/StaticCache.php
+++ b/core/components/statcache/elements/plugins/StaticCache.php
@@ -100,7 +100,8 @@ switch ($modx->event->name) {
                 array(
                     'deleteTop' => false,
                     'skipDirs' => false,
-                    'extensions' => array()
+                    'extensions' => array(),
+                    'delete_exclude_items' => explode(',', $modx->getOption('statcache_delete_exclude', $scriptProperties, ''))
                 )
             );
         }


### PR DESCRIPTION
This is useful if you have a .htaccess file in the statcache folder
