### PR TITLE
Fix for PHP fatal error in get() function

### DIFF
--- a/core/components/statcache/elements/plugins/StaticCache.php
+++ b/core/components/statcache/elements/plugins/StaticCache.php
@@ -144,7 +144,7 @@ switch ($modx->event->name) {
         }
         break;
     case 'OnDocFormSave':
-        if (empty($contexts) || in_array($modx->resource->get('context_key'), $contexts)) {
+        if (empty($contexts) || in_array($resource->get('context_key'), $contexts)) {
             if (empty($reloadOnly) && $modx->getOption('regenerate_on_save', $scriptProperties, true) && $resource->get('cacheable') && $resource->get('published')) {
                 /* Write a new static version of the file (if it already exists) when changes are saved */
                 $statcacheFile = StatCache::getInstance($modx, $scriptProperties)->getStaticPath($resource, $scriptProperties);


### PR DESCRIPTION
`$modx->resource->get('context_key')` on line 147 generates an error:
`PHP Fatal error:  Call to a member function get() on a non-object..`
Rewrote it to `$resource->get('context_key')` to solve the problem.
